### PR TITLE
Add a Firebase target with a 301 example

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "circonus.com:circonus"
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,8 @@ upload:
 
 deploy: build upload
 
+firebase-deploy:
+        firebase deploy
+
 server:
 	-@hugo server -w --disableFastRender

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,15 @@
+{
+  "hosting": {
+    "public": "public",
+    "redirects": [ {
+      "source": "/foo",
+      "destination": "/bar",
+      "type": 301
+    } ],
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}


### PR DESCRIPTION
This adds the Firebase cli to our build process, but it would avoid the complication of another hosting provider, set of accounts, billing, and all the rest. An example is up at https://circonus-com-circonus.web.app/ and a 301 is visible at https://circonus-com-circonus.web.app/foo . We can pull this down if we don't want to use Firebase, or point the docs.circonus.com domain at it if we do.

The CLI can be installed with `curl -sL https://firebase.tools | bash`, and permissions should inherit from our GCP Circonus project. `firebase deploy` will upload everything to Firebase, and it is in the make file.

If we go with this approach, I can update the build jobs and add docs.