### PR TITLE
Release notes 2020-04-20

### DIFF
--- a/content/circonus/on-premises/changelog/2020.md
+++ b/content/circonus/on-premises/changelog/2020.md
@@ -152,8 +152,10 @@ Version: 0.1.1586978979 (abda83c)
 
 ### Web UI/API
 
-Version: 0.1.1587142444 (4bc7dab)
+Version: 0.1.1587421536 (3df9624)
 
+* Bugfix: API was unable to set `prefer_reverse_connection=0` in the PUT
+  provision_broker call.
 * Bugfix: enterprise broker reachability UI notifications were being missed.
 
 ### web_stream

--- a/content/circonus/on-premises/changelog/2020.md
+++ b/content/circonus/on-premises/changelog/2020.md
@@ -28,11 +28,149 @@ release or later, but it will not hurt anything to run it more than once.
 for metric searches, so it is necessary to run this script before updating to
 the current release, if you have not already.**
 
+## 2020-04-20
+
+[EL7 pinned
+repo](/circonus/on-premises/installation/installation/#el7-repo):
+`baseurl=http://updates.circonus.net/centos/7/release-20200420/x86_64/`
+
+### caql_broker
+
+Version: 0.1.1587054536 (69ce22d)
+
+* Add tag-search result caching.
+* Performance improvements to message handling.
+
+### data_storage
+
+Related roles: caql_broker, fault_detection, stratcon
+
+Version: 0.1.1587050127 (3af5a96)
+
+**Function Removal Notice**
+
+> Metric Search v2 and Metric Clusters have been deprecated for some time.  We
+> plan to remove these deprecated functions soon for the SaaS site, and in the
+> subsequent Inside release. This will affect CAQL checks as well as CAQL
+> Datapoints on graphs. The UI will now show users a warning when one of the
+> deprecated functions is used. Circonus offers a more powerful tag-search
+> feature, exposed as `find()` in CAQL.
+
+* CAQL: Validate UUIDs passed to `metric:*` functions.
+* [raw ingestor] Lower default timeout/connect timeout for sending data to the
+  snowth cluster from 60s/2.5s to 8s/1s. This helps avoid backlogs when an
+  IRONdb node is responding slowly to ingestion.
+
+### fault_detection
+
+Version (faultd): 0.1.1586976934 (78b9ee0)
+
+* Fix numeric windows for patterns against all checks.
+
+Version (ernie): 0.1.1544639627 (db11a23)
+
+**Composite Checks Removal Notice**
+
+Since the [2019-05-06
+release](/circonus/on-premises/changelog/2019#2019-05-06), the `circonus-ernie`
+service has remained, serving its secondary role as a broker for [Composite
+checks](/circonus/checks/check-types/composite/). This functionality has been
+replaced and extended by [CAQL
+checks](/circonus/checks/check-types/caql-check/). The Composite check type,
+and the supporting service, will be removed in a future release. Operators and
+users of composite checks should immediately begin converting to CAQL checks.
+Please contact Circonus Support (support@circonus.com) with any questions.
+
+* No changes since [2018-12-31](/circonus/on-premises/changelog/2018#2018-12-31)
+
+### FQ
+
+Related roles: caql_broker, fault_detection, mq, stratcon, web_stream
+
+Version: 0.13.0
+
+* No changes since [2020-02-10](/circonus/on-premises/changelog/2020#2020-02-10)
+
+### GoAPI
+
+Related roles: api, web_frontend
+
+Version: 0.7.4
+
+* Improvements to memory utilization for resources shared between API and proxy
+  servers.
+* Fix: Improve validation error messages, on multiple endpoints, that were
+  confusing because they were being wrapped inside JSON decoding error
+  messages.
+* Improvements to the clarity of error messages returned by the `/data`
+  endpoint when required query parameters are missing or out of range.
+* Include a tag containing authentication information in the GoAPI
+  documentation.
+* Fix: Metric search pagination no longer returns an incorrect total count.
+* When annotations are created or modified, a check will be performed to verify
+  that any provided related metrics actually exist.
+* Validation has been improved for start and stop time fields for requests
+  placed to the `/annotation` endpoint.
+* Fix: Correct a problem where a successful annotation DELETE request would
+  return a 404 error code, even though the delete was successful.
+* Fix: If an account timezone is set to a non-null but empty string, the API
+  will now correctly return a validation error.
+
+### Hooper
+
+Version: 0.1.1586979176 (0c21e73)
+
+* Expose configuration for NNTBS timeshard retention. This is only valid for
+  deployments using the "nntbs" [backing store](/circonus/on-premises/installation/installation/#data_storage-attributes)
+  for the `data_storage` role.
+
+### libmtev
+
+Related roles: broker, caql_broker, data_storage, fault_detection, stratcon, web_stream
+
+Version: 1.10.2
+
+* No changes since [2020-04-06](/circonus/on-premises/changelog/2020#2020-04-06)
+
+### notification
+
+Version: 0.1.1570571834 (00b2aa2)
+
+* No changes since [2019-10-21](/circonus/on-premises/changelog/2019#2019-10-21)
+
+### Reconnoiter
+
+Related roles: broker, caql_broker, data_storage, fault_detection, stratcon, web_stream
+
+Version: 0.1.1586978979 (abda83c)
+
+* (Broker) Remove the C-based ssh2 check module. It was replaced with a Lua
+  version in 2018; this is just cleanup and removal of an external library
+  dependency.
+* (Broker) Drop outdated and unused modules: googleanalytics, keynote, and
+  keynote_pulse.
+
+### Web UI/API
+
+Version: 0.1.1587066090 (bc1aec8)
+
+* Bugfix: enterprise broker reachability UI notifications were being missed.
+
+### web_stream
+
+Version: 0.1.1566849557 (a3e7e11)
+
+* No changes since [2019-09-09](/circonus/on-premises/changelog/2019#2019-09-09)
+
+
 ## 2020-04-06
 
 [EL7 pinned
 repo](/circonus/on-premises/installation/installation/#el7-repo):
 `baseurl=http://updates.circonus.net/centos/7/release-20200406/x86_64/`
+
+**Note: This is the final release that will be supported for the EL6 and
+OmniOS platforms.**
 
 ### caql_broker
 

--- a/content/circonus/on-premises/changelog/2020.md
+++ b/content/circonus/on-premises/changelog/2020.md
@@ -152,7 +152,7 @@ Version: 0.1.1586978979 (abda83c)
 
 ### Web UI/API
 
-Version: 0.1.1587066090 (bc1aec8)
+Version: 0.1.1587142444 (4bc7dab)
 
 * Bugfix: enterprise broker reachability UI notifications were being missed.
 

--- a/content/circonus/on-premises/installation/getting-started.md
+++ b/content/circonus/on-premises/installation/getting-started.md
@@ -9,16 +9,16 @@ weight: 20
 
 |Component|CentOS 6|CentOS 7|
 |---|---|---|
-|Alert Management|Y|Y|
-|API|Y|Y|
-|Aggregator|Y|Y|
-|CA Management|Y|Y|
+|Alert Management|N|Y|
+|API|N|Y|
+|Aggregator|N|Y|
+|CA Management|N|Y|
 |Circonus Enterprise Broker|Y|Y|
-|Complex Event Processor|Y|Y|
-|Metadata Database|Y|Y|
+|Complex Event Processor|N|Y|
+|Metadata Database|N|Y|
 |Metrics Storage|N|Y|
-|Real-time OLAP|Y|Y|
-|Web Services|Y|Y|
+|Real-time OLAP|N|Y|
+|Web Services|N|Y|
 
 ## System Requirements
 
@@ -31,17 +31,10 @@ The Circonus Enterprise Broker is supported on the following platforms:
  * RHEL/CentOS 6 64-bit
  * RHEL/CentOS 7 64-bit
 
-### Data Storage
-
-The Circonus Data Storage component is supported on the following platforms:
-
- * RHEL/CentOS 7 64-bit
-
 ### All Other Components
 
 All other core system components are supported on the following platforms:
 
- * RHEL/CentOS 6 64-bit
  * RHEL/CentOS 7 64-bit
 
 ## Pre-Installation Checklist

--- a/content/circonus/on-premises/roles-services/web-db.md
+++ b/content/circonus/on-premises/roles-services/web-db.md
@@ -49,7 +49,6 @@ You should now have a new master DB and services should reconnect to it when nee
 ## Web DB Restart
 
 If certain configuration parameters are modified, Hooper will notify the operator that a database restart is required. Due to the potential disruption to related services, database restarts are not done automatically. If you need to restart the Web DB, execute one of the following commands, depending on the OS:
- * OmniOS: `svcadm restart svc:/database/postgres:circonus_wdb`
- * RHEL/CentOS: `service circonus-postgres-circonus_wdb restart`
+ * RHEL/CentOS: `systemctl restart circonus-postgres-circonus_wdb`
 
 Then restart each of the services that we recommend restarting after a Web DB restart.  See [Service Dependencies](/circonus/on-premises/service-dependencies).


### PR DESCRIPTION
Note that 2020-04-06 will be the last release for EL6 and OmniOS.

Update installation info with current support status for the various
components.

Fix web_db restart command to be correct for EL7.