### PR TITLE
CIRC-4909 Fix formatting on reconstitute page

### DIFF
--- a/content/circonus/on-premises/reconstituting-a-snowth-node.md
+++ b/content/circonus/on-premises/reconstituting-a-snowth-node.md
@@ -16,27 +16,17 @@ However, there are some important differences when performing this within the
 context of a Circonus Inside deployment:
  * No manual package installation is required. Hooper takes care of installing
    all of the necessary packages.
- * Make a note of this node's topology UUID. You can obtain this from
-   `/opt/circonus/var/chef-solo/data_bags/service_map/site.json`, in the
-   "machinfo" section, in the stanza for the host that will be reconstituted.
-   It is the "node\_id" attribute. Below, this will be referred to as
-   `<node_id>`.
- * The service name is `circonus-snowth` on EL7 and
-   `svc:/network/snowth:default` on OmniOS.
+ * The service name is `circonus-snowth`.
  * Filesystem paths start with `/snowth` instead of `/irondb`, but descendant
    directory structure is the same.
    * When getting the name of the base dataset, use
      ```
-BASE_DATASET=`zfs list -H -o name /snowth`
+     BASE_DATASET=`zfs list -H -o name /snowth`
      ```
  * Use the following command to start the reconstitute or to resume after an
    interruption:
    ```
-sudo /opt/circonus/sbin/snowthd 
--u nobody 
--g nobody 
--i <node uuid> 
--B 
+   sudo /opt/circonus/bin/snowth-start -B
    ```
 
 ## Building A Node In A New Cluster From The Old Cluster
@@ -49,23 +39,13 @@ However, there are some important differences when performing this within the
 context of a Circonus Inside deployment:
  * No manual package installation is required. Hooper takes care of installing
    all of the necessary packages.
- * Make a note of this node's topology UUID. You can obtain this from
-   `/opt/circonus/var/chef-solo/data_bags/service_map/site.json`, in the
-   "machinfo" section, in the stanza for the host that will be reconstituted.
-   It is the "node\_id" attribute. Below, this will be referred to as
-   `<node_id>`.
- * The service name is `circonus-snowth` on EL7 and
-   `svc:/network/snowth:default` on OmniOS.
+ * The service name is `circonus-snowth`.
  * Filesystem paths start with `/snowth` instead of `/irondb`, but descendant
    directory structure is the same.
  * Use the following command to start the reconstitute or to resume after an
    interruption:
    ```
-sudo /opt/circonus/sbin/snowthd 
--u nobody 
--g nobody 
--i <node uuid> 
--B 
--T <source_cluster_topo_hash>
--O <source_cluster_node_ip>:<port>
+   sudo /opt/circonus/bin/snowth-start -B \
+       -T <source_cluster_topo_hash> \
+       -O <source_cluster_node_ip>:<port>
    ```


### PR DESCRIPTION
The main issue was the indented code blocks, which were done a
different way in the pre-Hugo regime.

Remove the need to get the node ID, because we can just use the normal
start script with some extra args. The start script already knows how
to get the node ID.