### PR TITLE
CIRC-5873 Update network connection matrix

### DIFF
--- a/content/circonus/on-premises/installation/getting-started.md
+++ b/content/circonus/on-premises/installation/getting-started.md
@@ -214,29 +214,33 @@ If `source_port` is not defined, it is an ephemeral port.
 
 |To &rarr;<br>&darr; From|[API](/circonus/on-premises/components/#api)|[CA](/circonus/on-premises/components/#CA)|[CAQL Broker](/circonus/on-premises/components/#CAQLBroker)|[Data Storage](/circonus/on-premises/components/#DataStorage)|[Enterprise Broker](/circonus/on-premises/components/#enterprise-broker)|[Fault Detection](/circonus/on-premises/components/#FaultDetection)|[Hub](/circonus/on-premises/components/#Hub)|[Long-tail Store](/circonus/on-premises/components/#long-tail-store)|[MQ](/circonus/on-premises/components/#mq)|[Notification](/circonus/on-premises/components/#notification)|[Stratcon](/circonus/on-premises/components/#stratcon)|[Web DB](/circonus/on-premises/components/#WebDB)|[Web Frontend](/circonus/on-premises/components/#WebFrontend)|[Web Stream](/circonus/on-premises/components/#WebStream)|**Outside**|
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| [API](/circonus/on-premises/components/#api) | N/A | | | T::8112 | T::43191 | T::43191 | | | | | | T::5432 | T::11211 T::80 | | |
+| [API](/circonus/on-premises/components/#api) | N/A | | | T::8112 | T::43191 | | | | | | T::43191 T::[1025-65535]* | T::5432 | T::11211 T::80 | | |
 | [CA](/circonus/on-premises/components/#CA) | | N/A | | | | | | | | | | T::5432 | | | |
 | [CAQL Broker](/circonus/on-premises/components/#CAQLBroker) | T::8080 | | N/A | T::8112 | | | | | T::8765 | | | | | | |
 | [Data Storage](/circonus/on-premises/components/#DataStorage) | | | | T::8112 U:8112:8112 | | | | | | | | | | | |
 | [Enterprise Broker](/circonus/on-premises/components/#enterprise-broker) | | | | | N/A | | | | | | | | T::80 | | \*:\*:\*:\* |
-| [Fault Detection](/circonus/on-premises/components/#FaultDetection) | | | | T::8112 | | 225.0.1.9:U::8082 | | | T::5672 | | | T::5432 | T::80 | | |
-| [Hub](/circonus/on-premises/components/#Hub) | | | | T::8112 | T::43191 | | N/A | | T::5672 | | T::43191 | T::5432 | T::80 | T::8126 | |
+| [Fault Detection](/circonus/on-premises/components/#FaultDetection) | T::8080 | | | T::8112 | | T::43192 | | | T::5672 T::8765 | | | T::5432 | | | |
+| [Hub](/circonus/on-premises/components/#Hub) | | | | T::8112 | T::43191 | | N/A | | T::5672 | | T::43191 T::[1025-65535]* | T::5432 | T::80 | | |
 | [Long-tail Storage](/circonus/on-premises/components/#long-tail-store) | | | | | | | | N/A | | | | | | | |
 | [MQ](/circonus/on-premises/components/#mq) | | | | | | | | | T::4369 | | | | | | |
 | [Notification](/circonus/on-premises/components/#notification) | | | | | | | | | T::5672 | N/A | | T::5432 | T::80 | | |
-| [Stratcon](/circonus/on-premises/components/#stratcon) | | | | T::8112 | T::43191 | | | T::873 | T::5672 | | N/A | | T::80 | | |
-| [Web DB](/circonus/on-premises/components/#WebDB) | | | | | | | | | | | | T::5432 | | | |
-| [Web Frontend](/circonus/on-premises/components/#WebFrontend) | | | | T::8112 | T::43191 | T::43191 | | | | | T::43090 T::43191 | T::5432 | T::11211 | T::8126 | |
-| [Web Stream](/circonus/on-premises/components/#WebStream) | | | | | T::43191 | T::43191 | | | T::5672 | | | T::5432 | T::11211 T::80 | N/A | |
+| [Stratcon](/circonus/on-premises/components/#stratcon) | | | | T::8112 | T::43191 | | | T::873 | T::5672 T::8765 | | N/A | | T::80 | | |
+| [Web DB](/circonus/on-premises/components/#WebDB) | | | | | | | | | T::5672 | | | T::5432 | | | |
+| [Web Frontend](/circonus/on-premises/components/#WebFrontend) | | | | T::8112 | T::43191 | T::43191 | | | | | T::43191 T::[1025-65535]* | T::5432 | T::11211 | | |
+| [Web Stream](/circonus/on-premises/components/#WebStream) | | | | | | | | | T::8765 | | T::43191 T::[1025-65535]* | T::5432 | | N/A | |
 | Outside | T::8080 T::443| | | | U::8125 U::67 U::68 U::25826 T::43191 T::443 T::80 | | | | | | | | T::80 T::443 | T::80 T::9443 | N/A |
+
+\*Stratcon listens on ephemeral, unprivileged TCP ports for tunneling to reverse-mode brokers. These ports are opened as needed, one per reverse-mode broker.
 
 ### External Internet Access
 
 External internet access may or may not be required for some components, depending on your setup.
 
-The Web Frontend component requires external internet access if you intend to setup any SSO/OAuth at all for external providers, such as Slack or Google. This is necessary if you intend use cloudwatch checks.
+The Web Frontend component requires external internet access if you intend to
+setup any SSO/OAuth at all for external providers, such as Slack or Google. It
+is also necessary if you intend to use AWS Cloudwatch checks.
 
-The Notification component requires external internet access if you intend to use SMS alerts or Slack alerts.
+The Notification component requires external internet access if you intend to use SMS or Slack alerts.
 
 Web frontend:
 


### PR DESCRIPTION
API does not initiate connections to Fault Detection.

Remove multicast from Fault Detection, replace with faultd clustering.

Fault Detection does not initiate to Web Frontend.

Remove obsolete 8126 connections for old Web Stream (node.js Enzo).

Web DB connects to RabbitMQ.

API, Hub, Web Frontend, and Web Stream all connect to ephemeral ports
on Stratcon to reach reverse brokers.

Remove obsolete 43090 listener from Stratcon.

Add FQ (8765) connections.

Web Stream talks to FQ, not RabbitMQ, and does not talk to Web
Frontend.