### PR TITLE
Show allowed tag characters as literal list

### DIFF
--- a/content/circonus/checks/check-types/httptrap.md
+++ b/content/circonus/checks/check-types/httptrap.md
@@ -117,9 +117,10 @@ comma-separated list of `category:value` pairs. The tag section is separated
 from the metric name with a `|` (vertical bar). Here we have specified two
 tags, `env:prod` and `app:web`.
 
-Category strings may contain the following characters:
+Category strings may contain upper- and lowercase letters (A-Z and a-z),
+numerals (0-9), and the following characters:
 ```
-`+A-Za-z0-9!@#$%^&"'/?._-
+`+!@#$%^&"'/?._-
 ```
 
 Values may contain all of the above, plus colon (`:`) and equals (`=`).

--- a/content/circonus/checks/check-types/httptrap.md
+++ b/content/circonus/checks/check-types/httptrap.md
@@ -117,8 +117,8 @@ comma-separated list of `category:value` pairs. The tag section is separated
 from the metric name with a `|` (vertical bar). Here we have specified two
 tags, `env:prod` and `app:web`.
 
-Category strings may contain upper- and lowercase letters (A-Z and a-z),
-numerals (0-9), and the following characters:
+Category strings may contain upper- and lowercase letters (`A-Z` and `a-z`),
+numerals (`0-9`), and the following characters:
 ```
 `+!@#$%^&"'/?._-
 ```

--- a/content/circonus/checks/check-types/httptrap.md
+++ b/content/circonus/checks/check-types/httptrap.md
@@ -117,10 +117,9 @@ comma-separated list of `category:value` pairs. The tag section is separated
 from the metric name with a `|` (vertical bar). Here we have specified two
 tags, `env:prod` and `app:web`.
 
-Category strings may contain the following characters, shown here as a
-Perl-style regular expression:
+Category strings may contain the following characters:
 ```
-(?^:[`+A-Za-z0-9!@#\$%^&"'/\?\._-])
+`+A-Za-z0-9!@#$%^&"'/?._-
 ```
 
 Values may contain all of the above, plus colon (`:`) and equals (`=`).

--- a/content/irondb/tags.md
+++ b/content/irondb/tags.md
@@ -6,9 +6,11 @@ weight: 20
 # Tags
 
 Tags in IRONdb are represented as `category:value pairs` that are separated by the colon (`:`) character.
-Legal characters in an IRONdb tag category are defined by (perl RE syntax):
+Legal characters in an IRONdb tag category are:
 
-    perl -e '$valid = qr/[`+A-Za-z0-9!@#\$%^&"'\/\?\._-]/;
+```
+`+A-Za-z0-9!@#$%^&"'/?._-
+```
 
 Tag values allow all of the above characters plus colon (`:`) and equals (`=`).
 

--- a/content/irondb/tags.md
+++ b/content/irondb/tags.md
@@ -5,11 +5,14 @@ weight: 20
 
 # Tags
 
-Tags in IRONdb are represented as `category:value pairs` that are separated by the colon (`:`) character.
-Legal characters in an IRONdb tag category are:
+Tags in IRONdb are represented as `category:value pairs` that are separated by
+the colon (`:`) character.
+
+Category strings may contain upper- and lowercase letters (A-Z and a-z),
+numerals (0-9), and the following characters:
 
 ```
-`+A-Za-z0-9!@#$%^&"'/?._-
+`+!@#$%^&"'/?._-
 ```
 
 Tag values allow all of the above characters plus colon (`:`) and equals (`=`).

--- a/content/irondb/tags.md
+++ b/content/irondb/tags.md
@@ -8,8 +8,8 @@ weight: 20
 Tags in IRONdb are represented as `category:value pairs` that are separated by
 the colon (`:`) character.
 
-Category strings may contain upper- and lowercase letters (A-Z and a-z),
-numerals (0-9), and the following characters:
+Category strings may contain upper- and lowercase letters (`A-Z` and `a-z`),
+numerals (`0-9`), and the following characters:
 
 ```
 `+!@#$%^&"'/?._-


### PR DESCRIPTION
Replace the PCRE syntax with a simple list of the allowed characters.
This is easier to understand.