### PR TITLE
CIRC-6143 Add IRONdb-relay release notes

### DIFF
--- a/content/irondb/tools/irondb-grafana.md
+++ b/content/irondb/tools/irondb-grafana.md
@@ -1,6 +1,6 @@
 ---
 title: Grafana Data Source
-weight: 30
+weight: 20
 ---
 
 # Grafana Data Source

--- a/content/irondb/tools/irondb-relay-release-notes.md
+++ b/content/irondb/tools/irondb-relay-release-notes.md
@@ -1,0 +1,47 @@
+---
+title: IRONdb Relay Release Notes
+weight: 35
+---
+
+# IRONdb-relay Release Notes
+
+## 0.0.45
+
+2020-12-23
+
+* Adopt new Reconnoiter FlatBuffers implementation. **Requires IRONdb 0.19.15
+  or later.**
+
+
+## 0.0.44
+
+2020-10-26
+
+* Add new configuration option for HTTP compression. To enable compression, set
+  the attribute `compressed="true"` in the `<send>` XML node in
+  `irondb-relay.conf`. The default is `false` if not specified.
+
+
+## 0.0.43
+
+2020-07-23
+
+* Use safer string manipulation.
+* Fix NPE in watchdog config.
+
+
+## 0.0.42
+
+2020-04-09
+
+* Introduce a watchdog heartbeat on aggregator threads. Default is 300s
+  timeout, but this can be controlled via a module config parameter,
+  `watchdog_timeout`, which is a floating point value number of seconds.
+
+
+## 0.0.41
+
+2020-03-16
+
+* Adopt new libmtev 1.10 configuration read functions.
+

--- a/content/irondb/tools/irondb-relay.md
+++ b/content/irondb/tools/irondb-relay.md
@@ -1,6 +1,6 @@
 ---
 title: IRONdb Relay
-weight: 20
+weight: 30
 ---
 
 # IRONdb-relay
@@ -12,6 +12,8 @@ IRONdb storage node.
 Since IRONdb uses SHA256 hashing to route metrics to IRONdb nodes, it is
 incompatible with routing options that exist in carbon-c-relay and carbon-relay.
 In addition, it provides advanced aggregation and filtering functions.
+
+[Changelog](/irondb/tools/irondb-relay-release-notes/)
 
 ## Features
 
@@ -32,7 +34,7 @@ In addition, it provides advanced aggregation and filtering functions.
 ## Installation
 
 IRONdb-relay requires one of the following operating systems:
-* RHEL/CentOS, version 6.x, 7.x.
+* RHEL/CentOS 7.x.
 * Ubuntu 16.04 LTS.
 
 The following network protocols and ports are utilized. These are defaults and
@@ -51,24 +53,10 @@ the [IRONdb installation](/irondb/getting-started/manual-installation/#system-tu
 For EL7 or Ubuntu 16.04, use the same software source as the [IRONdb
 installation](/irondb/getting-started/manual-installation/#configure-software-sources).
 
-For EL6, create the file `/etc/yum.repos.d/Circonus.repo` with the following
-contents:
-```
-[circonus]
-name=Circonus
-baseurl=http://pilot.circonus.net/centos/6/x86_64/
-enabled = 1
-metadata_expire = 5m
-
-[circonus-crash-reporting]
-name=Circonus - Crash Reporting
-baseurl=http://updates.circonus.net/backtrace/centos/el6/
-enabled = 1
-```
 
 ## Install Package
 
-* (EL6, EL7) `/usr/bin/yum install circonus-platform-irondb-relay`
+* (EL7) `/usr/bin/yum install circonus-platform-irondb-relay`
 
 * (Ubuntu) `/usr/bin/apt-get install circonus-platform-irondb-relay`
 


### PR DESCRIPTION
Last five releases included, covering about the past year. Can do
more than this if desired.

Reorder the tools pages for consistency.