### PR TITLE
Document optional IRONdb integration module config

### DIFF
--- a/content/irondb/getting-started/configuration.md
+++ b/content/irondb/getting-started/configuration.md
@@ -755,6 +755,52 @@ currently-active topology. `next` is currently unused. The `redo` path is where
 
 No manual configuration of these settings is necessary.
 
+## Module Config
+
+The [integration modules](/irondb/integrations) that provide support for
+ingesting Graphite and/or OpenTSDB data have optional configuration, described
+below. These settings are placed in the main `irondb.conf` file, as children of
+the `<snowth>` node (i.e., peers of `<logs>`, `<topology>`, etc.) If omitted,
+the defaults shown below will be used.
+
+### Graphite Config
+
+```
+<graphite min_rollup_span_ms="60000" max_ingest_age="365d"/>
+```
+
+#### graphite max_ingest_age
+
+The maximum offset into the past from "now" that will be accepted. Value may be
+any valid [libmtev duration
+string](http://circonus-labs.github.io/libmtev/apireference/c.html#mtevgetdurationss).
+If importing older data, it may be necessary to increase this value.
+
+Default: 1 year
+
+#### graphite min_rollup_span_ms
+
+The smallest rollup period that is being collected. This prevents gaps when
+requesting data at shorter intervals.
+
+Default: 1 minute
+
+### OpenTSDB Config
+
+```
+<opentsdb max_ingest_age="365d"/>
+```
+
+#### opentsdb max_ingest_age
+
+The maximum offset into the past from "now" that will be accepted. Value may be
+any valid [libmtev duration
+string](http://circonus-labs.github.io/libmtev/apireference/c.html#mtevgetdurationss).
+If importing older data, it may be necessary to increase this value.
+
+Default: 1 year
+
+
 ## Included Files
 
 ### circonus-watchdog.conf

--- a/content/irondb/integrations/graphite.md
+++ b/content/irondb/integrations/graphite.md
@@ -90,6 +90,14 @@ using the "Network Listener" below, will result in a metric called:
 This allows us to disambiguate metric names from potential duplicate names
 collected using Reconnoiter.
 
+## Optional Configuration
+
+Graphite ingestion will, by default, accept timestamps up to 1 year in the
+past. When retrieving Graphite data, a floor of 1-minute resolution is used, to
+prevent gaps if the requested period is shorter. These values may be changed
+through
+[configuration](/irondb/getting-started/configuration/#graphite-config).
+
 ## Writing Graphite Data with HTTP
 
 Graphite data is sent as buffers of N rows of graphite formatted data to the

--- a/content/irondb/integrations/opentsdb.md
+++ b/content/irondb/integrations/opentsdb.md
@@ -8,25 +8,6 @@ title: OpenTSDB
 
 IRONdb has native endpoints for accepting OpenTSDB-style data.
 
-### Enable the OpenTSDB Module
-
-> As of version 0.17.0, the OpenTSDB module is active by default for new
-> installations. If you previously activated the module using the instructions
-> below, you may remove the line from `irondb-modules-site.conf` after
-> upgrading to 0.17.0 or later, but it is not an error if the line appears more
-> than once.
-
-IRONdb must be [configured](/irondb/getting-started/configuration/) such that the OpenTSDB module is
-enabled for reading or writing OpenTSDB data natively. OpenTSDB support is
-activated by adding the following line:
-```
-<generic image="opentsdb" name="opentsdb"/>
-```
-to `/opt/circonus/etc/irondb-modules-site.conf` on each IRONdb node. This file
-preserves local modifications across package updates. A [service
-restart](/irondb/administration/operations/#service-management) is required after changing
-configuration.
-
 ### Ingestion Format
 
 There are 2 methods for ingesting OpenTSDB data into IRONdb:
@@ -142,6 +123,12 @@ collection category ("reconnoiter" will be automatically assigned) and the
 
 Adding these additional fields allow us to disambiguate metric names from
 potential duplicate names collected from other sources.
+
+## Optional Configuration
+
+OpenTSDB ingestion will, by default, accept timestamps up to 1 year in the
+past. This value may be changed through
+[configuration](/irondb/getting-started/configuration/#graphite-config).
 
 ## Writing OpenTSDB Data with HTTP
 

--- a/content/irondb/integrations/opentsdb.md
+++ b/content/irondb/integrations/opentsdb.md
@@ -128,7 +128,7 @@ potential duplicate names collected from other sources.
 
 OpenTSDB ingestion will, by default, accept timestamps up to 1 year in the
 past. This value may be changed through
-[configuration](/irondb/getting-started/configuration/#graphite-config).
+[configuration](/irondb/getting-started/configuration/#opentsdb-config).
 
 ## Writing OpenTSDB Data with HTTP
 


### PR DESCRIPTION
Graphite and OpenTSDB modules have options controlling aspects of
ingestion and data retrieval.

Remove OpenTSDB enablement info, as it has been enabled by default
for nearly 2 years.